### PR TITLE
[BUGFIX] Adding Sanitizer to Back End User Attr. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'rack-cors', require: 'rack/cors'
 gem 'faker'
 gem 'active_model_serializers'
 gem 'devise_token_auth'
+gem 'prettier'
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     pg (1.1.4)
+    prettier (0.15.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -220,6 +221,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
+  prettier
   pry-byebug
   pry-rails
   puma (~> 3.11)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,11 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :role])
+  end
+
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,5 @@
 class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
-  def render_create_success    
+  def render_create_success
     5.times { RegistrationKey.create(user: @resource) }
     @resource.reload
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   extend Devise::Models
   after_initialize :set_default_role, if: :new_record?
 
-  enum role: [:university, :research_group, :reader]
+  enum role: { university: 0, research_group: 1, reader: 2 }
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,3 @@
-
 require 'coveralls'
 Coveralls.wear_merged!('rails')
 require 'spec_helper'

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Api::V0::ArticlesController, type: :request do
-  let(:headers) { {HTTP_ACCEPT: "application/json"} }
+  let(:headers) { { HTTP_ACCEPT: 'application/json' } }
 
   describe 'GET /v0/articles' do
     before do
@@ -7,15 +7,12 @@ RSpec.describe Api::V0::ArticlesController, type: :request do
       get '/api/v0/articles', headers: headers
     end
 
-
-    it 'should return collection of articles' do    
+    it 'should return collection of articles' do
       expect(response_json.count). to eq 5
     end
 
     it 'returns 200 response' do
       expect(response.status).to eq 200
     end
-
   end
 end
-

--- a/spec/requests/api/v0/registrations_spec.rb
+++ b/spec/requests/api/v0/registrations_spec.rb
@@ -1,72 +1,60 @@
 RSpec.describe 'User Registration', type: :request do
   let(:header) { { HTTP_ACCEPT: 'application/json' } }
 
-  context 'with valid credentials' do
-    it 'returns a user info and 5 registration keys' do
+  describe 'with valid credentials' do
+    before 'posting data to URL' do
       post '/api/v0/auth', params: { email: 'example@craftacademy.se',
-                                      password: 'password',
-                                      password_confirmation: 'password'
-                                  }, headers: headers
+                                     name: 'Fat Bob',
+                                     role: 'research_group',
+                                     password: 'password',
+                                     password_confirmation: 'password' },
+                                     headers: headers
+    end
 
-      expect(response_json['status']).to eq 'success'
+    it 'returns a 200 response' do
       expect(response.status).to eq 200
+    end
+
+    it 'returns 5 registration keys' do
       expect(response_json['data']['registration_keys'].count).to eq 5
     end
-    
+
     it 'JSON body response contains a role' do
-      post '/api/v0/auth', params: { email: 'example@craftacademy.se',
-                                      password: 'password',
-                                      password_confirmation: 'password',
-                                      role: 'research_group'
-                                  }, headers: headers
-      
-      expect(response_json['data']['user']['role']).to eq "research_group"
+      expect(response_json['data']['user']['role']).to eq 'research_group'
     end
 
     it 'JSON body response contains a name ' do
-      post '/api/v0/auth', params: { email: 'example@craftacademy.se',
-                                      name: 'Dr. Rockso',
-                                      password: 'password',
-                                      password_confirmation: 'password'
-                                  }, headers: headers
-      
-      expect(response_json['data']['user']['name']).to eq "Dr. Rockso"
+      expect(response_json['data']['user']['name']).to eq 'Fat Bob'
     end
   end
 
-  context 'returns an error message when user submits' do
-    it 'non-matching password confirmation' do
-      post '/api/v0/auth', params: { email: 'example@craftacademy.se',
-                                      password: 'password',
-                                      password_confirmation: 'wrong_password'
-                                  }, headers: headers
+  describe 'returns an error message when user submits' do
+    before 'posting erroneous data to URL' do
+      post '/api/v0/auth', params: { email: 'example@craftacademy',
+                                     password: 'password',
+                                     password_confirmation: 'wrong_password' },
+                                     headers: headers
+    end
 
-      expect(response_json['errors']['password_confirmation']).to eq ["doesn't match Password"]
-      expect(response.status).to eq 422
+    it 'non-matching password confirmation' do
+      expect(response_json['errors']['password_confirmation']).to eq ["doesn't match password"]
     end
 
     it 'an invalid email address' do
-      post '/api/v0/auth', params: { email: 'example@craft',
-                                      password: 'password',
-                                      password_confirmation: 'password'
-                                  }, headers: headers
-
       expect(response_json['errors']['email']).to eq ['is not an email']
-      expect(response.status).to eq 422
     end
+  end
 
-    it 'an already registered email' do
-      FactoryBot.create(:user, email: 'example@craftacademy.se',
-                                password: 'password',
-                                password_confirmation: 'password')
+  it 'an already registered email' do
+    FactoryBot.create(:user, email: 'example@craftacademy.se',
+                             password: 'password',
+                             password_confirmation: 'password')
 
-      post '/api/v0/auth', params: { email: 'example@craftacademy.se',
-                                      password: 'password',
-                                      password_confirmation: 'password'
-                                  }, headers: headers
+    post '/api/v0/auth', params: { email: 'example@craftacademy.se',
+                                   password: 'password',
+                                   password_confirmation: 'password' }, headers:
+                                   headers
 
-      expect(response_json['errors']['email']).to eq ['has already been taken']
-      expect(response.status).to eq 422
-    end
+    expect(response_json['errors']['email']).to eq ['has already been taken']
   end
 end

--- a/spec/requests/api/v0/registrations_spec.rb
+++ b/spec/requests/api/v0/registrations_spec.rb
@@ -13,15 +13,23 @@ RSpec.describe 'User Registration', type: :request do
       expect(response_json['data']['registration_keys'].count).to eq 5
     end
     
-    it 'JSON body response contains a name and a role' do
+    it 'JSON body response contains a role' do
       post '/api/v0/auth', params: { email: 'example@craftacademy.se',
-                                      name: 'Dr. Rockso',
                                       password: 'password',
                                       password_confirmation: 'password',
                                       role: 'research_group'
                                   }, headers: headers
       
       expect(response_json['data']['user']['role']).to eq "research_group"
+    end
+
+    it 'JSON body response contains a name ' do
+      post '/api/v0/auth', params: { email: 'example@craftacademy.se',
+                                      name: 'Dr. Rockso',
+                                      password: 'password',
+                                      password_confirmation: 'password'
+                                  }, headers: headers
+      
       expect(response_json['data']['user']['name']).to eq "Dr. Rockso"
     end
   end

--- a/spec/requests/api/v0/registrations_spec.rb
+++ b/spec/requests/api/v0/registrations_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe 'User Registration', type: :request do
       expect(response.status).to eq 200
       expect(response_json['data']['registration_keys'].count).to eq 5
     end
+    
+    it 'JSON body response contains a name and a role' do
+      post '/api/v0/auth', params: { email: 'example@craftacademy.se',
+                                      name: 'Dr. Rockso',
+                                      password: 'password',
+                                      password_confirmation: 'password',
+                                      role: 'research_group'
+                                  }, headers: headers
+      
+      expect(response_json['data']['user']['role']).to eq "research_group"
+      expect(response_json['data']['user']['name']).to eq "Dr. Rockso"
+    end
   end
 
   context 'returns an error message when user submits' do

--- a/spec/requests/api/v0/registrations_spec.rb
+++ b/spec/requests/api/v0/registrations_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'User Registration', type: :request do
     end
 
     it 'non-matching password confirmation' do
-      expect(response_json['errors']['password_confirmation']).to eq ["doesn't match password"]
+      expect(response_json['errors']['password_confirmation']).to eq ["doesn't match Password"]
     end
 
     it 'an invalid email address' do


### PR DESCRIPTION
Users signing up from the front end were unable to save the appropriate role to the backend.  After demo with Oliver & Thomas, we added a sanitizer to the application controller which allows the new data (role) to be added to the user.

Also modified enums iterator in the User model to clearly illustrate number values.

Pivotal Tracker Link: https://www.pivotaltracker.com/story/show/168023503