### PR TITLE
FIX - Reg Controller JSON Response for User Attr. After Signup

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,8 +5,7 @@ class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
 
     render json: {
       status: 'success',
-      data: resource_data,
-      registration_keys: @resource.registration_keys
+      data: resource_data.merge(registration_keys: @resource.registration_keys)
     }
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,14 +1,12 @@
 class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
   def render_create_success
     5.times { RegistrationKey.create(user: @resource) }
-    @resource.reload
+    @resource.reload    
 
     render json: {
       status: 'success',
-      data: {
-        registration_keys: @resource.registration_keys,
-        user: resource_data
-      }
+      data: resource_data,
+      registration_keys: @resource.registration_keys
     }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ActiveRecord::Base
   has_many :registration_keys
   has_many :articles
 
-  private 
+  private
 
   def set_default_role
     self.role ||= :reader

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,16 @@ ActiveRecord::Schema.define(version: 2019_08_21_095125) do
     t.index ["user_id"], name: "index_registration_keys_on_user_id"
   end
 
+  create_table "universities", force: :cascade do |t|
+    t.string "name"
+    t.string "resource_type"
+    t.bigint "resource_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "resource_type", "resource_id"], name: "index_universities_on_name_and_resource_type_and_resource_id"
+    t.index ["resource_type", "resource_id"], name: "index_universities_on_resource_type_and_resource_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
@@ -61,6 +71,14 @@ ActiveRecord::Schema.define(version: 2019_08_21_095125) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+  end
+
+  create_table "users_universities", id: false, force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "university_id"
+    t.index ["university_id"], name: "index_users_universities_on_university_id"
+    t.index ["user_id", "university_id"], name: "index_users_universities_on_user_id_and_university_id"
+    t.index ["user_id"], name: "index_users_universities_on_user_id"
   end
 
   add_foreign_key "registration_keys", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,16 +32,6 @@ ActiveRecord::Schema.define(version: 2019_08_21_095125) do
     t.index ["user_id"], name: "index_registration_keys_on_user_id"
   end
 
-  create_table "universities", force: :cascade do |t|
-    t.string "name"
-    t.string "resource_type"
-    t.bigint "resource_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name", "resource_type", "resource_id"], name: "index_universities_on_name_and_resource_type_and_resource_id"
-    t.index ["resource_type", "resource_id"], name: "index_universities_on_resource_type_and_resource_id"
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
@@ -71,14 +61,6 @@ ActiveRecord::Schema.define(version: 2019_08_21_095125) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
-  end
-
-  create_table "users_universities", id: false, force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "university_id"
-    t.index ["university_id"], name: "index_users_universities_on_university_id"
-    t.index ["user_id", "university_id"], name: "index_users_universities_on_user_id_and_university_id"
-    t.index ["user_id"], name: "index_users_universities_on_user_id"
   end
 
   add_foreign_key "registration_keys", "users"

--- a/spec/requests/api/v0/registrations_spec.rb
+++ b/spec/requests/api/v0/registrations_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe 'User Registration', type: :request do
     end
 
     it 'JSON body response contains a role' do
-      expect(response_json['data']['user']['role']).to eq 'research_group'
+      expect(response_json['data']['role']).to eq 'research_group'
     end
 
     it 'JSON body response contains a name ' do
-      expect(response_json['data']['user']['name']).to eq 'Fat Bob'
+      expect(response_json['data']['name']).to eq 'Fat Bob'
     end
   end
 


### PR DESCRIPTION
This bugfix relates to the  ```render_create_success``` method in the Registrations Controller.

Previously, the render json action was using nested json to return user attributes which didn't work, so after a successful user signup, the user's attributes (resource_data) weren't making it back to the front end.  This is relevant because if the front end can't see the user's attributes, key features of the UI won't be displayed (Create Article, for instance).

Pivotal Tracker Link:
https://www.pivotaltracker.com/story/show/168038889