### PR TITLE
Research group can sign up with key

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::API
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :role, :university_id])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :role])
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::API
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :role])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :role, :university_id])
   end
 
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,7 +5,7 @@ class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
     build_resource
     if params[:role] == 'research_group'
       if params[:registration_key].nil?
-        render_json_error_response('Need a registration key') and return
+        render_json_error_response('Registration key is required for Sign up') and return
       end
 
       reg_key = RegistrationKey.find_by(combination: params[:registration_key])

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -68,8 +68,6 @@ class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
 
   end
   
-  
-  
   def render_create_success
     if @resource.role === 'university'  
       5.times { RegistrationKey.create(user: @resource) }
@@ -81,6 +79,7 @@ class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
       registration_keys: @resource.registration_keys,
       data: resource_data
     }
+    binding.pry
   end
 
   def render_json_error_response(message)
@@ -90,4 +89,5 @@ class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
       errors: message
     }, status: 422
   end
+
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,7 +3,7 @@ class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
   def create
 
     build_resource
-    if params[:role] === 'research_group'
+    if params[:role] == 'research_group'
       if params[:registration_key].nil?
         render_json_error_response('Need a registration key') and return
       end
@@ -69,7 +69,7 @@ class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
   end
   
   def render_create_success
-    if @resource.role === 'university'  
+    if @resource.role == 'university'  
       5.times { RegistrationKey.create(user: @resource) }
       @resource.reload
     end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,8 +1,10 @@
 class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
   def render_create_success
+    if @resource.role === 'university'  
     5.times { RegistrationKey.create(user: @resource) }
     @resource.reload
-
+    end
+    
     render json: {
       status: 'success',
       data: {

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -78,7 +78,16 @@ class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
     
     render json: {
       status: 'success',
-      data: resource_data.merge(registration_keys: @resource.registration_keys)
+      registration_keys: @resource.registration_keys,
+      data: resource_data
     }
+  end
+
+  def render_json_error_response(message)
+    render json: {
+      status: 'error',
+      data:   resource_data,
+      errors: message
+    }, status: 422
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -79,7 +79,6 @@ class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
       registration_keys: @resource.registration_keys,
       data: resource_data
     }
-    binding.pry
   end
 
   def render_json_error_response(message)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,4 +1,75 @@
 class RegistrationsController < ::DeviseTokenAuth::RegistrationsController
+  
+  def create
+
+    build_resource
+    if params[:role] === 'research_group'
+      if params[:registration_key].nil?
+        render_json_error_response('Need a registration key') and return
+      end
+
+      reg_key = RegistrationKey.find_by(combination: params[:registration_key])
+
+      unless reg_key.nil?
+        @resource.university = reg_key.user 
+      else
+        render_json_error_response('Invalid registration key') and return
+      end
+    end 
+  
+
+    # every line of code for the rest of the create action is devise code
+    unless @resource.present?
+      raise DeviseTokenAuth::Errors::NoResourceDefinedError,
+            "#{self.class.name} #build_resource does not define @resource,"\
+            ' execution stopped.'
+    end
+
+    @redirect_url = params.fetch(
+      :confirm_success_url,
+      DeviseTokenAuth.default_confirm_success_url
+    )
+
+    if confirmable_enabled? && !@redirect_url
+      return render_create_error_missing_confirm_success_url
+    end
+
+    return render_create_error_redirect_url_not_allowed if blacklisted_redirect_url?
+
+    resource_class.set_callback('create', :after, :send_on_create_confirmation_instructions)
+    resource_class.skip_callback('create', :after, :send_on_create_confirmation_instructions)
+
+    if @resource.respond_to? :skip_confirmation_notification!
+      @resource.skip_confirmation_notification!
+    end
+
+    if @resource.save
+      yield @resource if block_given?
+
+      unless @resource.confirmed?
+        @resource.send_confirmation_instructions({
+          client_config: params[:config_name],
+          redirect_url: @redirect_url
+        })
+      end
+
+      if active_for_authentication?
+        @token = @resource.create_token
+        @resource.save!
+        update_auth_header
+      end
+
+      render_create_success
+      
+    else
+      clean_up_passwords @resource
+      render_create_error
+    end
+
+  end
+  
+  
+  
   def render_create_success
     if @resource.role === 'university'  
       5.times { RegistrationKey.create(user: @resource) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,10 @@ class User < ActiveRecord::Base
   has_many :registration_keys
   has_many :articles
 
+  has_many :research_groups, class_name: "User", foreign_key: "university_id"
+
+  belongs_to :university, class_name: "User", optional: true
+
   private
 
   def set_default_role

--- a/db/migrate/20190822141427_add_association_between_university_and_research_group.rb
+++ b/db/migrate/20190822141427_add_association_between_university_and_research_group.rb
@@ -1,0 +1,5 @@
+class AddAssociationBetweenUniversityAndResearchGroup < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :users, :university
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,7 +57,6 @@ ActiveRecord::Schema.define(version: 2019_08_22_141427) do
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.integer "role"
-    t.string "sign_up_registration_key"
     t.bigint "university_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_21_095125) do
+ActiveRecord::Schema.define(version: 2019_08_22_141427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,10 +57,13 @@ ActiveRecord::Schema.define(version: 2019_08_21_095125) do
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.integer "role"
+    t.string "sign_up_registration_key"
+    t.bigint "university_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+    t.index ["university_id"], name: "index_users_on_university_id"
   end
 
   add_foreign_key "registration_keys", "users"

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe 'Registration', type: :request do
   let(:header) { { HTTP_ACCEPT: 'application/json' } }
-  let(:registration_key) { 'o7A8pJcuvzhv7fih9Paak3nt' }
-  let(:university) { FactoryBot.create(:user, role: 'university') }
+  let(:university) { create(:user, role: 'university') }
   let(:reg_key) { university.registration_keys.create }
 
   describe 'of User with Research Group role with valid Registration Key' do

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe 'Registration', type: :request do
       expect(response_json["data"]["university_id"]).to eq reg_key.user_id
     end
 
+    it 'it does not create registration key for research group user' do
+      expect(response_json["registration_keys"].count).to eq 0
+    end
   end
 
   describe 'of User with Research Group role without Registration Key' do

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'Registration', type: :request do
     it 'it does not create registration key for research group user' do
       expect(response_json["registration_keys"].count).to eq 0
     end
+    
   end
 
   describe 'of User with Research Group role without Registration Key' do

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe 'User Registration', type: :request do
   let(:header) { { HTTP_ACCEPT: 'application/json' } }
+  let(:registration_key) { 'o7A8pJcuvzhv7fih9Paak3nt' }
 
   describe 'User with Research Group role signs up with Registration Key' do
     before 'post new User with Research Group role info' do
@@ -8,7 +9,7 @@ RSpec.describe 'User Registration', type: :request do
                                      role: 'research_group',
                                      password: 'password',
                                      password_confirmation: 'password',
-                                     registration_key: 'registration_key' },
+                                     registration_key: registration_key },
                                      headers: headers
     end
 
@@ -22,8 +23,7 @@ RSpec.describe 'User Registration', type: :request do
     end
 
     it 'verifies that created user have a Registration key' do
-      registration_key = User.last.registration_key
-      expect(registration_key).to eq '8288912'
+      expect(response_json['data']['user']['registration_key']).to eq registration_key
     end
   
   end

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe 'User Registration', type: :request do
+  let(:header) { { HTTP_ACCEPT: 'application/json' } }
+
+  describe 'User with Research Group role signs up with Registration Key' do
+    before 'post new User with Research Group role info' do
+      post '/api/v0/auth', params: { email: 'example@craftacademy.se',
+                                     name: 'Research Group Alpha',
+                                     role: 'research_group',
+                                     password: 'password',
+                                     password_confirmation: 'password' },
+                                     headers: headers
+    end
+
+  end
+
+end

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe 'Registration', type: :request do
   let(:header) { { HTTP_ACCEPT: 'application/json' } }
+  let(:registration_key) { 'o7A8pJcuvzhv7fih9Paak3nt' }
   let(:university) { FactoryBot.create(:user, role: 'university') }
   let(:reg_key) { university.registration_keys.create }
 
   describe 'of User with Research Group role with valid Registration Key' do
-
     before 'post new User info' do
       post '/api/v0/auth', params: { email: 'example@craftacademy.se',
                                     name: 'Research Group Alpha',
@@ -17,14 +17,19 @@ RSpec.describe 'Registration', type: :request do
 
     it 'returns a 200 response if post request was successful' do
       expect(response.status).to eq 200
+      binding.pry
     end
 
     it 'verifies that User with Research Group role is created' do
       expect(response_json["data"]["name"]).to eq 'Research Group Alpha'
     end
 
-    it 'verifies that the registration key used for research_group sign up is associated with a university' do
+    it 'verifies that created University has a Registration key' do
       expect(response_json["data"]["university_id"]).to eq reg_key.user_id
+    end
+    
+    it 'verifes that Research group are associated with the University thats created' do
+      expect(User.find_by(email: 'example@craftacademy.se').university_id).to eq university.id
     end
 
   end

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe 'Registration', type: :request do
   let(:header) { { HTTP_ACCEPT: 'application/json' } }
-  let(:registration_key) { 'o7A8pJcuvzhv7fih9Paak3nt' }
   let(:university) { FactoryBot.create(:user, role: 'university') }
   let(:reg_key) { university.registration_keys.create }
 
@@ -24,7 +23,7 @@ RSpec.describe 'Registration', type: :request do
       expect(response_json["data"]["name"]).to eq 'Research Group Alpha'
     end
 
-    it 'verifies that created user have a Registration key' do
+    it 'verifies that the registration key used for research_group sign up is associated with a university' do
       expect(response_json["data"]["university_id"]).to eq reg_key.user_id
     end
 

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -7,10 +7,15 @@ RSpec.describe 'User Registration', type: :request do
                                      name: 'Research Group Alpha',
                                      role: 'research_group',
                                      password: 'password',
-                                     password_confirmation: 'password' },
+                                     password_confirmation: 'password',
+                                     registration_key: 'registration_key' },
                                      headers: headers
     end
 
+    it 'returns a 200 response if post request was successful' do
+      expect(response.status). to eq 200
+    end
+  
   end
 
 end

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe 'Registration', type: :request do
 
     it 'returns a 200 response if post request was successful' do
       expect(response.status).to eq 200
-      binding.pry
     end
 
     it 'verifies that User with Research Group role is created' do
@@ -53,11 +52,15 @@ RSpec.describe 'Registration', type: :request do
       expect(response_json["errors"]).to eq 'Need a registration key'
     end
 
+    it 'checks for research group saved in db, but fails' do
+      expect(User.find_by(email: 'maria@craftacademy.se')).to eq nil
+    end
+
   end
 
   describe 'of User with Research Group role incorrect Registration Key' do
     before 'post new User info' do
-      post '/api/v0/auth', params: { email: 'maria@craftacademy.se',
+      post '/api/v0/auth', params: { email: 'sam@craftacademy.se',
                                      name: 'Fat Jesus',
                                      role: 'research_group',
                                      password: 'password',
@@ -72,6 +75,27 @@ RSpec.describe 'Registration', type: :request do
 
     it 'returns error message' do
       expect(response_json["errors"]).to eq 'Invalid registration key'
+    end
+
+    it 'checks for research group saved in db, but fails' do
+      expect(User.find_by(email: 'sam@craftacademy.se')).to eq nil
+    end
+
+  end
+
+  describe 'of User with University role trying to use Registration Key' do
+    before 'post new User info' do
+      post '/api/v0/auth', params: { email: 'tate@craftacademy.se',
+                                     name: 'Fat Jesus',
+                                     role: 'university',
+                                     password: 'password',
+                                     password_confirmation: 'password',
+                                     registration_key: reg_key.combination },
+                                     headers: headers
+    end
+
+    it '(hack) tries to associate new User with university role with the University thats created, but fails' do
+      expect(User.find_by(email: 'tate@craftacademy.se').university_id).to eq nil
     end
 
   end

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -13,7 +13,12 @@ RSpec.describe 'User Registration', type: :request do
     end
 
     it 'returns a 200 response if post request was successful' do
-      expect(response.status). to eq 200
+      expect(response.status).to eq 200
+    end
+
+    it 'verifies that User with Research Group role is created' do
+      name = User.last.name
+      expect(name).to eq 'Research Group Alpha'
     end
   
   end

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -1,31 +1,54 @@
-RSpec.describe 'User Registration', type: :request do
+# RSpec.describe 'User Registration', type: :request do
+#   let(:header) { { HTTP_ACCEPT: 'application/json' } }
+
+#   describe 'User with Research Group role signs up with Registration Key' do
+#     before 'post new User with Research Group role info' do
+#       post '/api/v0/auth', params: { email: 'example@craftacademy.se',
+#                                      name: 'Research Group Alpha',
+#                                      role: 'research_group',
+#                                      password: 'password',
+#                                      password_confirmation: 'password',
+#                                      registration_key: 'registration_key' },
+#                                      headers: headers
+#     end
+
+#     it 'returns a 200 response if post request was successful' do
+#       expect(response.status).to eq 200
+#     end
+
+#     it 'verifies that User with Research Group role is created' do
+#       name = User.last.name
+#       expect(name).to eq 'Research Group Alpha'
+#     end
+
+#     it 'verifies that created user have a Registration key' do
+#       registration_key = User.last.registration_key
+#       expect(registration_key).to eq '8288912'
+#     end
+  
+#   end
+
+# end
+
+RSpec.describe 'Research Group Registration', type: :request do
   let(:header) { { HTTP_ACCEPT: 'application/json' } }
 
-  describe 'User with Research Group role signs up with Registration Key' do
-    before 'post new User with Research Group role info' do
-      post '/api/v0/auth', params: { email: 'example@craftacademy.se',
-                                     name: 'Research Group Alpha',
+  describe 'with valid credentials' do
+    before 'posting data to URL' do
+      post '/api/v0/auth', params: { email: 'maria@craftacademy.se',
+                                     name: 'Fat Jesus',
                                      role: 'research_group',
                                      password: 'password',
-                                     password_confirmation: 'password',
-                                     registration_key: 'registration_key' },
+                                     password_confirmation: 'password' },
                                      headers: headers
     end
 
-    it 'returns a 200 response if post request was successful' do
+    it 'returns a 200 response' do
       expect(response.status).to eq 200
     end
 
-    it 'verifies that User with Research Group role is created' do
-      name = User.last.name
-      expect(name).to eq 'Research Group Alpha'
+    it 'returns 0 registration keys' do
+      expect(response_json['data']['registration_keys'].count).to eq 0
     end
-
-    it 'verifies that created user have a Registration key' do
-      registration_key = User.last.registration_key
-      expect(registration_key).to eq '8288912'
-    end
-  
   end
-
 end

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe 'User Registration', type: :request do
       name = User.last.name
       expect(name).to eq 'Research Group Alpha'
     end
+
+    it 'verifies that created user have a Registration key' do
+      registration_key = User.last.registration_key
+      expect(registration_key).to eq '8288912'
+    end
   
   end
 

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Registration', type: :request do
-  let(:header) { { HTTP_ACCEPT: 'application/json' } }
+  let(:headers) { { HTTP_ACCEPT: 'application/json' } }
   let(:university) { create(:user, role: 'university') }
   let(:reg_key) { university.registration_keys.create }
 
@@ -22,12 +22,8 @@ RSpec.describe 'Registration', type: :request do
       expect(response_json["data"]["name"]).to eq 'Research Group Alpha'
     end
 
-    it 'verifies that created University has a Registration key' do
+    it 'verifes that Research group are associated with the University thats created the reg-key' do
       expect(response_json["data"]["university_id"]).to eq reg_key.user_id
-    end
-    
-    it 'verifes that Research group are associated with the University thats created' do
-      expect(User.find_by(email: 'example@craftacademy.se').university_id).to eq university.id
     end
 
   end
@@ -43,12 +39,12 @@ RSpec.describe 'Registration', type: :request do
                                      headers: headers
     end
 
-    it 'returns a 422 response, save successfully attempted but nothing saved' do
+    it 'returns a 422 response' do
       expect(response.status).to eq 422
     end
 
     it 'returns error message' do
-      expect(response_json["errors"]).to eq 'Need a registration key'
+      expect(response_json["errors"]).to eq 'Registration key is required for Sign up'
     end
 
     it 'checks for research group saved in db, but fails' do
@@ -68,7 +64,7 @@ RSpec.describe 'Registration', type: :request do
                                      headers: headers
     end
 
-    it 'returns a 422 response, save successfully attempted but nothing saved' do
+    it 'returns a 422 response' do
       expect(response.status).to eq 422
     end
 

--- a/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
+++ b/spec/requests/api/v0/research_group_sign_up_with_key_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe 'Registration', type: :request do
     end
 
     it 'verifies that User with Research Group role is created' do
-      expect(response_json[:name]).to eq 'Research Group Alpha'
+      expect(response_json["data"]["name"]).to eq 'Research Group Alpha'
     end
 
     it 'verifies that created user have a Registration key' do
-      expect(response_json[:university_id]).to eq reg_key.user_id
+      expect(response_json["data"]["university_id"]).to eq reg_key.user_id
     end
 
   end
@@ -46,7 +46,7 @@ RSpec.describe 'Registration', type: :request do
     end
 
     it 'returns error message' do
-      expect(response_json[:error]).to eq 'Need a registration key'
+      expect(response_json["errors"]).to eq 'Need a registration key'
     end
 
   end
@@ -67,7 +67,7 @@ RSpec.describe 'Registration', type: :request do
     end
 
     it 'returns error message' do
-      expect(response_json[:error]).to eq 'Invalid registration key'
+      expect(response_json["errors"]).to eq 'Invalid registration key'
     end
 
   end

--- a/spec/requests/api/v0/university_registrations_spec.rb
+++ b/spec/requests/api/v0/university_registrations_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'User Registration', type: :request do
     before 'posting data to URL' do
       post '/api/v0/auth', params: { email: 'example@craftacademy.se',
                                      name: 'Fat Bob',
-                                     role: 'research_group',
+                                     role: 'university',
                                      password: 'password',
                                      password_confirmation: 'password' },
                                      headers: headers

--- a/spec/requests/api/v0/university_registrations_spec.rb
+++ b/spec/requests/api/v0/university_registrations_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'User Registration', type: :request do
+RSpec.describe 'University Registration', type: :request do
   let(:header) { { HTTP_ACCEPT: 'application/json' } }
 
   describe 'with valid credentials' do
@@ -20,7 +20,7 @@ RSpec.describe 'User Registration', type: :request do
     end
 
     it 'JSON body response contains a role' do
-      expect(response_json['data']['user']['role']).to eq 'research_group'
+      expect(response_json['data']['user']['role']).to eq 'university'
     end
 
     it 'JSON body response contains a name ' do

--- a/spec/requests/api/v0/university_registrations_spec.rb
+++ b/spec/requests/api/v0/university_registrations_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe 'University Registration', type: :request do
     end
 
     it 'returns 5 registration keys' do
-      expect(response_json['data']['registration_keys'].count).to eq 5
+      expect(response_json['registration_keys'].count).to eq 5
     end
 
     it 'JSON body response contains a role' do
-      expect(response_json['data']['user']['role']).to eq 'university'
+      expect(response_json['data']['role']).to eq 'university'
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe 'University Registration', type: :request do
     end
 
     it 'returns zero registration keys' do
-      expect(response_json['data']['registration_keys'].count).to eq 0
+      expect(response_json['registration_keys']).to eq nil
     end
 
   end

--- a/spec/requests/api/v0/university_registrations_spec.rb
+++ b/spec/requests/api/v0/university_registrations_spec.rb
@@ -24,22 +24,6 @@ RSpec.describe 'University Registration', type: :request do
     end
   end
 
-  describe 'with valid credentials for Research Group role' do
-    before 'post new Research Group info' do
-      post '/api/v0/auth', params: { email: 'example@craftacademy.se',
-                                    name: 'Fat Bob',
-                                    role: 'research_group',
-                                    password: 'password',
-                                    password_confirmation: 'password' },
-                                    headers: headers
-    end
-
-    it 'returns zero registration keys' do
-      expect(response_json['registration_keys']).to eq nil
-    end
-
-  end
-
   describe 'returns an error message when user submits' do
     before 'posting erroneous data to URL' do
       post '/api/v0/auth', params: { email: 'example@craftacademy',

--- a/spec/requests/api/v0/university_registrations_spec.rb
+++ b/spec/requests/api/v0/university_registrations_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe 'User Registration', type: :request do
   let(:header) { { HTTP_ACCEPT: 'application/json' } }
 
-  describe 'with valid credentials' do
-    before 'posting data to URL' do
+  describe 'with valid credentials for University role' do
+    before 'post new University info' do
       post '/api/v0/auth', params: { email: 'example@craftacademy.se',
                                      name: 'Fat Bob',
                                      role: 'university',
@@ -20,12 +20,24 @@ RSpec.describe 'User Registration', type: :request do
     end
 
     it 'JSON body response contains a role' do
-      expect(response_json['data']['user']['role']).to eq 'research_group'
+      expect(response_json['data']['user']['role']).to eq 'university'
+    end
+  end
+
+  describe 'with valid credentials for Research Group role' do
+    before 'post new Research Group info' do
+      post '/api/v0/auth', params: { email: 'example@craftacademy.se',
+                                    name: 'Fat Bob',
+                                    role: 'research_group',
+                                    password: 'password',
+                                    password_confirmation: 'password' },
+                                    headers: headers
     end
 
-    it 'JSON body response contains a name ' do
-      expect(response_json['data']['user']['name']).to eq 'Fat Bob'
+    it 'returns zero registration keys' do
+      expect(response_json['data']['registration_keys'].count).to eq 0
     end
+
   end
 
   describe 'returns an error message when user submits' do


### PR DESCRIPTION
PivotalTracker - https://www.pivotaltracker.com/story/show/167917098

- Refactor registrations_spec.rb so that it only tests for User with University role.

- Request spec for sign up user: research group role should have a key with many happy and sad paths.

- Refactor Registration Controller to only generate keys for user: university role.

- Refactor associations for the roles of User in the model, research group and university with "classname" user.

- Generate migration file to make associaton between university-user and research group-user

- Make instance associations between User: university role and User: research group role when registration_key is used

- Merge latest upstream and resolve conflicts
