### PR TITLE
BUGFIX: Stripe Payment Not Going Through

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,10 @@ module GnosisApi
       config.middleware.insert_before 0, Rack::Cors do
         allow do
           origins '*'
-          resource '*', headers: :any, methods: [:get, :post, :options]
+          resource '*', 
+            headers: :any, 
+            methods: %i[get post put delete],
+            expose: %w(access-token expiry token-type uid client)
         end
       end
     end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,7 +5,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.


### PR DESCRIPTION
### User Story

```
N/A
```
### Feature description
https://www.pivotaltracker.com/story/show/168138137

### Description of PR
The stripe payment was not going through and we were getting an 402 error "Payment Required". After refactoring the Payment method we got to the point where we found that we were not sending the needed params to the API to make the request to Stripe.

On the backend, we need to expose the headers(that contain our credentials) w/ Rack Cors and also stop devise from resetting the headers with every reload

### Screenshots
N/A

### What did we learn?
-In order for the front end to access the current_user's information and send it to the backend (when posting a payment, for instance) the headers need to be exposed on the backend with RackCors.
-Also, by default, devise's authorization headers change after each request (from the front end). The client is responsible for keeping track of the changing tokens. Change this default behavior false to prevents the authorization header from changing after each request.
